### PR TITLE
Explicit dependencies and avoid importing boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-botocore==0.24.0
+botocore>=0.24.0
 six>=1.4.0
-jmespath==0.1.0
+jmespath>=0.1.0
 python-dateutil>=2.1
 
 # Someday...

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ requires = [
     'six>=1.4.0',
     'jmespath>=0.1.0',
     'python-dateutil>=2.1',
+    'bcdoc==0.12.2'
+]
+
+dependency_links = [
+    'git+https://github.com/boto/bcdoc.git@develop#egg=bcdoc'
 ]
 
 setup(
@@ -46,6 +51,7 @@ setup(
     },
     include_package_data=True,
     install_requires=requires,
+    dependency_links=dependency_links,
     license=open("LICENSE").read(),
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,10 @@ distutils/setuptools install script.
 """
 
 import os
+import re
 import sys
-import boto3
+import codecs
+# import boto3
 
 try:
     from setuptools import setup
@@ -14,6 +16,26 @@ try:
 except ImportError:
     from distutils.core import setup
 
+
+here=os.path.abspath(os.path.dirname(__file__))
+
+
+# Read the version number from a source file.
+# Why read it, and not import?
+# see https://groups.google.com/d/topic/pypa-dev/0PkjVpcxTzQ/discussion
+def find_version(*file_paths):
+    # Open in Latin-1 so that we avoid encoding errors.
+    # Use codecs.open for Python 2 compatibility
+    with codecs.open(os.path.join(here, *file_paths), 'r', 'latin1') as f:
+        version_file=f.read()
+
+    # The version line must have the form
+    # __version__='ver'
+    version_match=re.search(r"^__version__ = \(([^'\",]*),\s*([^'\",]*),\s*([^'\",]*).*\)",
+                            version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
 
 packages = [
     'boto3',
@@ -36,7 +58,8 @@ dependency_links = [
 
 setup(
     name='boto3',
-    version=boto3.get_version(),
+    # version=boto3.get_version(),
+    version=find_version('boto3', '__init__.py'),
     description='Low-level, data-driven core of boto 3.',
     long_description=open('README.rst').read(),
     author='Amazon Web Services',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def find_version(*file_paths):
     version_match=re.search(r"^__version__ = \(([^'\",]*),\s*([^'\",]*),\s*([^'\",]*).*\)",
                             version_file, re.M)
     if version_match:
-        return version_match.group(1)
+        return "{}.{}.{}".format(version_match.group(1), version_match.group(2), version_match.group(3))
     raise RuntimeError("Unable to find version string.")
 
 packages = [

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ packages = [
 ]
 
 requires = [
-    'botocore==0.24.0',
+    'botocore>=0.24.0',
     'six>=1.4.0',
-    'jmespath==0.1.0',
+    'jmespath>=0.1.0',
     'python-dateutil>=2.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import os
 import re
 import sys
 import codecs
-# import boto3
 
 try:
     from setuptools import setup
@@ -58,7 +57,6 @@ dependency_links = [
 
 setup(
     name='boto3',
-    # version=boto3.get_version(),
     version=find_version('boto3', '__init__.py'),
     description='Low-level, data-driven core of boto 3.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
Hi,

Thanks for your work on boto3!

In this PR, I bring these two install-related items:
1. Read version information from `boto3/__init__.py` using a regex (thus without importing boto3 inside `setup.py`). This is how `pandas` does it. It makes the installation a bit neater. I had to adapt the regex to your way of expressing the version info in `__init__.py`.
2. add an explicit dependency on `bcdoc`.

As such, a simple `pip install boto3` just works. I tested it on a private pypi-server.

Hope it helps,
Regards,
Romain
